### PR TITLE
Timeline Renders in Realtime; Invisible on Weekends

### DIFF
--- a/static/js/redux/ui/calendar.jsx
+++ b/static/js/redux/ui/calendar.jsx
@@ -155,7 +155,6 @@ class Calendar extends React.Component {
 				</ReactTooltip>
 			</div>
 	    );
-		console.log("render");
 		return (
 	      <div id="calendar" className="fc fc-ltr fc-unthemed week-calendar">
 	        <div className="fc-toolbar no-print">


### PR DESCRIPTION
The timeline for the calendar now renders in real time, updating
every minute. On Saturdays and Sundays, the timeline no longer
renders.

This addresses all features mentioned in issue #531.