### PR TITLE
prevented slot from being added to queue twice, queue evaluates how m…

### DIFF
--- a/static/js/redux/ui/slot_manager.jsx
+++ b/static/js/redux/ui/slot_manager.jsx
@@ -119,6 +119,9 @@ class SlotManager extends React.Component {
             // bit map to store if slot has already been processed
             let seen = day_slots.map(() => false)
 
+            // bit map to store if slot has already been added to queue
+            let added = day_slots.map(() => false)
+
             // get num_conflicts + shift_index
             for (let i = 0; i < info_intervals.length; i++) {
                 if (!seen[i]) { // if not seen, perform dfs search on conflicts
@@ -127,11 +130,13 @@ class SlotManager extends React.Component {
                     while (frontier.length > 0) {
                         let next = frontier.pop()
                         seen[next.id] = true
+                        added[next.id] = true
                         direct_conflicts.push(next)
                         let neighbors = getIntersections(info_slots, next)
                         for (let k = 0; k < neighbors.length; k++) {
-                            if (!seen[neighbors[k].id]) {
+                            if (!seen[neighbors[k].id] && !added[neighbors[k].id]) {
                                 frontier.push(neighbors[k])
+                                added[neighbors[k].id] = true
                             }
                         }
                     }


### PR DESCRIPTION
…any courses conflict

#777 

basically the for loop that loops over neighbors was adding courses twice to the queue "frontier"
so I added another bitmap to store which slots were already added to the queue