### PR TITLE
Chapman bugfix for skipping closed courses

### DIFF
--- a/scripts/peoplesoft/courses.py
+++ b/scripts/peoplesoft/courses.py
@@ -378,10 +378,14 @@ class PeoplesoftParser(CourseParser):
 		''' Virtually refined search (to get around min search param requirement). '''
 		query = {}
 		query['SSR_CLSRCH_WRK_SSR_OPEN_ONLY$chk$4'] = 'N'
+		query['SSR_CLSRCH_WRK_SSR_OPEN_ONLY$chk$5'] = 'N'
 		for day in ['MON', 'TUES', 'WED', 'THURS', 'FRI', 'SAT', 'SUN']:
 			query['SSR_CLSRCH_WRK_' + day + '$5'] = 'Y'
 			query['SSR_CLSRCH_WRK_' + day + '$chk$5'] = 'Y'
+			query['SSR_CLSRCH_WRK_' + day + '$6'] = 'Y'
+			query['SSR_CLSRCH_WRK_' + day + '$chk$6'] = 'Y'
 		query['SSR_CLSRCH_WRK_INCLUDE_CLASS_DAYS$5'] = 'J'
+		query['SSR_CLSRCH_WRK_INCLUDE_CLASS_DAYS$6'] = 'J'
 		# query[soup.find('select', id=re.compile(r'SSR_CLSRCH_WRK_INSTRUCTION_MODE\$\d'))['id']] = 'P'
 		# NOTE: above was removed to handle missed courses, not sure how this will effect all parsers (tested: salisbury, chapman, umich, queens)
 		return query


### PR DESCRIPTION
Peoplesoft requests take different number so refine search was not
allowing for closed classes. This is now fixed. Note that extra request
params are ignored by Peoplesoft server.