### PR TITLE
Temporarily ignore course filled bug

### DIFF
--- a/student/views.py
+++ b/student/views.py
@@ -134,9 +134,11 @@ def convert_tt_to_dict(timetable, include_last_updated=True):
             courses[-1]['slots'] = []
             courses[-1]['enrolled_sections'] = []
             courses[-1]['textbooks'] = {}
+            courses[-1]['is_waitlist_only'] = False
 
         index = course_ids.index(c.id)
-        courses[index]['slots'].extend([merge_dicts(get_section_dict(section_obj), model_to_dict(co)) for co in section_obj.offering_set.all()])
+        courses[index]['slots'].extend([merge_dicts(get_section_dict(section_obj), model_to_dict(co))
+                                        for co in section_obj.offering_set.all()])
         courses[index]['textbooks'][section_obj.meeting_section] = section_obj.get_textbooks()
 
         courses[index]['enrolled_sections'].append(section_obj.meeting_section)
@@ -145,8 +147,10 @@ def convert_tt_to_dict(timetable, include_last_updated=True):
         course_section_list = sorted(course_obj.section_set.filter(semester=timetable.semester),
                                      key=lambda s: s.section_type)
         section_type_to_sections = itertools.groupby(course_section_list, lambda s: s.section_type)
-        index = course_ids.index(course_obj.id)
-        courses[index]['is_waitlist_only'] = any(sections_are_filled(sections) for _, sections in section_type_to_sections)
+        if course_obj.id in course_ids:
+            index = course_ids.index(course_obj.id)
+            courses[index]['is_waitlist_only'] = any(sections_are_filled(sections)
+                                                     for _, sections in section_type_to_sections)
 
     tt_dict['courses'] = courses
     tt_dict['avg_rating'] = get_avg_rating(course_ids)


### PR DESCRIPTION
Addresses exception raised on line 148 in student.views:
```
"/home/django/semesterly/student/views.py", line 148, in convert_tt_to_dict
    index = course_ids.index(course_obj.id)
ValueError: 28388 is not in list
```
It is currently unknown why this occurs, since this implies that there is a course in `timetable.courses.all()` which is not associated with any section in `timetable.sections.all()`.
As a temporary solution, we do not update the `is_waitlist_only` fields for these courses (they stay `False` by default).

We ignore a more permanent fix since this error does not occur for the `convert_tt_to_dict` implementation in `timetable.views`, which will eventually replace the one in `student.views` (having duplicate functions was a mistake in the first place) and resolve this issue.