### PR TITLE
Classmates View Passing Tests

### DIFF
--- a/static/js/redux/actions/user_actions.jsx
+++ b/static/js/redux/actions/user_actions.jsx
@@ -122,7 +122,6 @@ export const fetchClassmates = courses => (dispatch) => {
       .courses.map(c => c.id)));
   }, 500);
   dispatch(requestClassmates());
-  console.log("COURSES", courses);
   fetch(getClassmatesEndpoint(allSemesters[semesterIndex], courses), {
     credentials: 'include',
     method: 'GET',

--- a/student/tests.py
+++ b/student/tests.py
@@ -234,7 +234,7 @@ class ClassmateViewTest(APITestCase):
         self.factory = APIRequestFactory()
 
     def test_get_classmate_counts(self):
-        request = self.factory.get('/user/classmates/Fall/2000/', {'counts': True, 'course_ids': [1]})
+        request = self.factory.get('/user/classmates/Fall/2000/', {'count': True, 'course_ids[]': [1]})
         force_authenticate(request, user=self.user2)
         request.subdomain = 'uoft'
         view = resolve('/user/classmates/Fall/2016/').func
@@ -247,7 +247,7 @@ class ClassmateViewTest(APITestCase):
         })
 
     def test_get_classmates(self):
-        request = self.factory.get('/user/classmates/Fall/2000/', {'course_ids': [1]})
+        request = self.factory.get('/user/classmates/Fall/2000/', {'course_ids[]': [1]})
         force_authenticate(request, user=self.user2)
         request.subdomain = 'uoft'
         view = resolve('/user/classmates/Fall/2016/').func

--- a/student/views.py
+++ b/student/views.py
@@ -237,7 +237,7 @@ class ClassmateView(ValidateSubdomainMixin, APIView):
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, sem_name, year):
-        if request.query_params.get('counts'):
+        if request.query_params.get('count'):
             school = request.subdomain
             student = Student.objects.get(user=request.user)
             course_ids = map(int, request.query_params.getlist('course_ids[]'))


### PR DESCRIPTION
When the browser passes a list to the backend it actually sends one assignment to the same key (the name of that list param) to the backend. Assigning the value at each point in the array to the name:

```
course_ids = [1,2,3]
url?course_ids=1&course_ids=2&course_ids=3
```

Servers receive this as a new variable called 'course_ids[]' to indicate that it is a list. 

I discovered that to test this, we must manually name the key to a list with the appended '[]'. See code for more details. Tests now pass and frontend works. 
