### PR TITLE
Uoft parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A Timetable Generator",
   "dependencies": {
+    "autoprefixer": "^7.1.1",
     "babel": "^6.23.0",
     "babel-core": "^6.24.1",
     "babel-loader": "^6.4.1",
@@ -80,7 +81,8 @@
     "watch": "node server.js",
     "lint-staged": "lint-staged",
     "lint-fix": "./node_modules/.bin/eslint --fix static/js/redux/* static/js/redux/alerts/* static/js/redux/actions/* static/js/redux/constants/* static/js/redux/reducers/* static/js/redux/ui/containers/* static/js/redux/ui/alerts/*",
-    "lint": "./node_modules/.bin/eslint static/js/redux/*/*; ./node_modules/.bin/sass-lint -c .scss-lint.yml 'static/css/timetable/*.scss, static/css/timetable/base/*.scss' -v -q"
+    "lint": "./node_modules/.bin/eslint static/js/redux/*/*; ./node_modules/.bin/sass-lint -c .scss-lint.yml 'static/css/timetable/*.scss, static/css/timetable/base/*.scss' -v -q",
+    "validate": "npm ls"
   },
   "repository": {
     "type": "git",

--- a/scripts/uoft/uoft_courses.py
+++ b/scripts/uoft/uoft_courses.py
@@ -495,7 +495,9 @@ class UofTParser:
               tr.a.extract()
               name = tr.find('b').text.strip()[2:]
               level = code[3].upper()
-              assert level in ["A", "B", "C", "D"]
+              if level not in ["A", "B", "C", "D"]:
+                i += 1
+                continue
               print "On Course:", code, ":", name, "\n"
               course_details = self.get_course_details(code, course_link)
               C, created = Course.objects.update_or_create(code=code, school="uoft", defaults={


### PR DESCRIPTION
changes:
- update urls for utm/utsg
- update parser to use new semester format (use Semester model instead of FSY)
- ignore grad courses for now to avoid dealing with levels logic

this fixes utsg and utsc but utm's page format has changed so updating the parser for utm will take more time