### PR TITLE
fixed sharelink overlapping friendcircles in masterslots

### DIFF
--- a/static/css/timetable/partials/side_bar.scss
+++ b/static/css/timetable/partials/side_bar.scss
@@ -265,6 +265,7 @@
     position: absolute;
     right: 5px;
     top: 20px;
+    z-index: 1;
 
     .tip {
       right: 12px;


### PR DESCRIPTION
fixed sharelink overlapping friendcircles in masterslots

this was wicked confusing