### PR TITLE
Queens Section Display Bugfix

### DIFF
--- a/scripts/parser_library/digestor.py
+++ b/scripts/parser_library/digestor.py
@@ -262,6 +262,8 @@ class DigestionAdapter:
 			'Lecture': 'L',
 			'Laboratory': 'P',
 			'Discussion': 'T',
+			'Seminar': 'T',
+			'Tutorial': 'T',
 		}
 		if 'type' in section:
 			adapted['section_type'] = section_type_map.get(section.type, 'L')


### PR DESCRIPTION
### WHAT
Add queens sections that were being categorized as lectures

### WHY
Issue caused Queens users to only be able to add either lectures or seminars, not both

### HOW
Add seminars and tutorials to the section map in digestor