### PR TITLE
dedupe list of dictionaries correctly

### DIFF
--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -79,7 +79,7 @@ class CourseSerializer(serializers.ModelSerializer):
 
     def get_textbooks(self, course):
         sections = course.section_set.filter(semester=self.context['semester'])
-        all_textbooks = (tb for section in section for tb in section.get_textbooks())
+        all_textbooks = (tb for section in sections for tb in section.get_textbooks())
         unique_textbooks = []
         seen_textbooks = set()
         for tb in all_textbooks:


### PR DESCRIPTION
use a set of ids to keep track of unique dictionaries