### PR TITLE
Fix styling for rtfd

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,8 +187,5 @@ html_theme = "sphinx_rtd_theme"
 
 html_static_path = ['_static']
 
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+def setup(app):
+    app.add_stylesheet('theme_overrides.css') 


### PR DESCRIPTION
Previously used html_context which causes breakages in css/theme for ReadTheDocs.io. 