### PR TITLE
#1003 fixed unrounded slotbar corners in master slot

### DIFF
--- a/static/css/timetable/partials/timetable.scss
+++ b/static/css/timetable/partials/timetable.scss
@@ -89,6 +89,7 @@ button {
   position: absolute;
   width: 5px !important;
   z-index: 0;
+  border-radius: 5px 0 0 5px;
 }
 
 .fc-content {


### PR DESCRIPTION
#1003 
Caused by new share course link modal feature which removed `overflow: hidden` on the master slot