### PR TITLE
Remove queens

### DIFF
--- a/helpers/mixins.py
+++ b/helpers/mixins.py
@@ -35,7 +35,9 @@ class ValidateSubdomainMixin(object):
     """
 
     def dispatch(self, request, *args, **kwargs):
-        if request.subdomain not in ACTIVE_SCHOOLS:
+        if request.subdomain == "queens":
+            return render(request, 'queens_error.html')
+        elif request.subdomain not in ACTIVE_SCHOOLS:
             return render(request, 'index.html')
         return super(ValidateSubdomainMixin, self).dispatch(request, *args, **kwargs)
 

--- a/semesterly/templates/about.html
+++ b/semesterly/templates/about.html
@@ -46,7 +46,7 @@
 					<a href="https://jhu.semester.ly">JHU</a>
 					<a href="https://umd.semester.ly">UMD</a>
 					<a href="https://uoft.semester.ly">UofT</a>
-					<a href="https://queens.semester.ly">Queen's</a>
+					<!--<a href="https://queens.semester.ly">Queen's</a>-->
 				</nav>
 			</div>
 		</header>

--- a/semesterly/templates/queens_error.html
+++ b/semesterly/templates/queens_error.html
@@ -1,0 +1,82 @@
+{% load staticfiles %}
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+    <meta name="description" content="Now with a new and improved UI: find courses with friends, view course reactions, and use Advanced Search to find the course that fits all your needs. Alternatively, explore new options with our recommendation engine – helping you find new and exciting courses on the fly. Not sure if the class is worthwhile? Instantly see what your peers think, alongside detailed comments from past course evaluations. Currently supporting course finding software for the Johns Hopkins University (JHU), the University of Toronto (UofT) and the University of Maryland (UMD).">
+    <meta name="author" content="Noah Presler, Rohan Das, Felix Zhu, Max Yeo, Eric Calder">
+
+    <!-- Facebook thumbnail info -->
+    <meta property="og:title" content="Queens Page Not Found | Semester.ly - Course Scheduling Made Easy" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Semesterly" />
+    <meta property="og:url" content="http://semester.ly" />
+    <meta property="og:image" content="http://i.imgur.com/Eem4KTj.png" />
+    <meta property="og:description" content="Now with a new and improved UI: find courses with friends, view course reactions, and use Advanced Search to find the course that fits all your needs. Alternatively, explore new options with our recommendation engine – helping you find new and exciting courses on the fly. Not sure if the class is worthwhile? Instantly see what your peers think, alongside detailed comments from past course evaluations." />
+    <meta property="fb:admins" content="535129063" />
+
+    <title>404 Page Not Found | Semester.ly: Course Scheduling, Textbooks, Social & More</title>
+    <link rel="shortcut icon" type="image/x-icon" href="{% static 'img/logo2.0-310x310.png' %}" />
+
+    <link href="https://fonts.googleapis.com/css?family=Palanquin:500|Roboto:100,300,400" rel="stylesheet" type='text/css'>
+    <link rel="stylesheet" href="{% static 'css/global.css'%}">
+    <link rel="stylesheet" href="{% static 'css/course-page.css'%}">
+    <link rel="stylesheet" href="{% static 'css/unsubscribe.css'%}">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+
+    <!-- Google Analytics script -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-68704308-1', 'auto');
+      ga('send', 'pageview');
+
+    </script>
+</head>
+<body>
+<header>
+    <div class="grid cf">
+        <a href="/">
+            <span id="logo"></span>
+            <h1>Semester.ly</h1>
+        </a>
+        <!-- <div id="social">
+            <div id="social-card">
+                <div id="social-pro-pic" style="background-image: url();"></div>
+                <h2>Max</h2>
+                <span class="tip-down"></span>
+            </div>
+            <div id="social-dropdown">
+                <div class="tip-border"></div>
+                <div class="tip"></div>
+                <a href="/user/logout">
+                    <i class="fa fa-sign-out"></i>
+                    <span>Sign out</span>
+                </a>
+            </div>
+            <a id="social-login" href="/login/facebook">
+                <h2>Signup/Login <i className="fa fa-facebook-square"></i></h2>
+            </a>
+        </div> -->
+    </div>
+</header>
+
+<div id="error-404">
+    <div id="error-404-center">
+        <img src="{% static 'img/email/sad.png' %}" />
+        <h2>Queens is currently not available</h2>
+        <br>
+        <h2>by request of the university</h2>
+        <h3>Page Not Found.<br> Go back to <a href="/">Semester.ly</a></h3>
+    </div>
+</div>
+
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+<script type="text/javascript" src="{% static 'js/splash.js'%}"></script>
+</body>
+</html>

--- a/semesterly/templates/queens_error.html
+++ b/semesterly/templates/queens_error.html
@@ -17,7 +17,7 @@
     <meta property="og:description" content="Now with a new and improved UI: find courses with friends, view course reactions, and use Advanced Search to find the course that fits all your needs. Alternatively, explore new options with our recommendation engine – helping you find new and exciting courses on the fly. Not sure if the class is worthwhile? Instantly see what your peers think, alongside detailed comments from past course evaluations." />
     <meta property="fb:admins" content="535129063" />
 
-    <title>404 Page Not Found | Semester.ly: Course Scheduling, Textbooks, Social & More</title>
+    <title>Queens Unavailable | Semester.ly: Course Scheduling, Textbooks, Social & More</title>
     <link rel="shortcut icon" type="image/x-icon" href="{% static 'img/logo2.0-310x310.png' %}" />
 
     <link href="https://fonts.googleapis.com/css?family=Palanquin:500|Roboto:100,300,400" rel="stylesheet" type='text/css'>

--- a/timetable/templates/header.html
+++ b/timetable/templates/header.html
@@ -39,7 +39,7 @@
 					<a href="https://jhu.semester.ly">JHU</a>
 					<a href="https://umd.semester.ly">UMD</a>
 					<a href="https://uoft.semester.ly">UofT</a>
-					<a href="https://queens.semester.ly">Queen's</a>
+					<!--<a href="https://queens.semester.ly">Queen's</a>-->
 				</nav>
 			</div>
 		</header>

--- a/timetable/templates/index.html
+++ b/timetable/templates/index.html
@@ -47,7 +47,7 @@
 						<a href="https://jhu.semester.ly">JHU</a>
 						<a href="https://umd.semester.ly">UMD</a>
 						<a href="https://uoft.semester.ly">UofT</a>
-						<a href="https://queens.semester.ly">Queen's</a>
+						<!--<a href="https://queens.semester.ly">Queen's</a>-->
 						<a href="https://vandy.semester.ly">Vandy</a>
 						<a href="https://gw.semester.ly">GW</a>
 						<a href="https://umich.semester.ly">UMich</a>
@@ -67,7 +67,7 @@
 								<a href="https://jhu.semester.ly">JHU</a>
 								<a href="https://umd.semester.ly">UMD</a>
 								<a href="https://uoft.semester.ly">UofT</a>
-								<a href="https://queens.semester.ly">Queen's</a>
+								<!--<a href="https://queens.semester.ly">Queen's</a>-->
 								<a href="https://vandy.semester.ly">Vandy</a>
 								<a href="https://gw.semester.ly">GW</a>
 								<a href="https://umich.semester.ly">UMich</a>
@@ -97,10 +97,10 @@
 								<div class="square-logo" style="background-image: url(/static/img/school_logos/uoft-square.png);"></div>
 								<span>University of Toronto</span>
 							</a>
-							<a href="https://queens.semester.ly">
-								<div class="square-logo" style="background-image: url(/static/img/school_logos/qu-square.png);"></div>
-								<span>Queen's University</span>
-							</a>
+							<!--<a href="https://queens.semester.ly">-->
+								<!--<div class="square-logo" style="background-image: url(/static/img/school_logos/qu-square.png);"></div>-->
+								<!--<span>Queen's University</span>-->
+							<!--</a>-->
 							<a href="https://vandy.semester.ly">
 								<div class="square-logo" style="background-image: url(/static/img/school_logos/vandy-square.png);"></div>
 								<span>Vanderbilt University</span>
@@ -219,10 +219,10 @@
 									<div class="square-logo" style="background-image: url(/static/img/school_logos/uoft-square.png);"></div>
 									<span>UofT</span>
 								</a>
-								<a href="https://queens.semester.ly">
-									<div class="square-logo" style="background-image: url(/static/img/school_logos/qu-square.png);"></div>
-									<span>Queen's</span>
-								</a>
+								<!--<a href="https://queens.semester.ly">-->
+									<!--<div class="square-logo" style="background-image: url(/static/img/school_logos/qu-square.png);"></div>-->
+									<!--<span>Queen's</span>-->
+								<!--</a>-->
 								<a href="https://vandy.semester.ly">
 									<div class="square-logo" style="background-image: url(/static/img/school_logos/vandy-square.png);"></div>
 									<span>Vandy</span>

--- a/timetable/templates/profile.html
+++ b/timetable/templates/profile.html
@@ -45,7 +45,7 @@
 						<a href="https://jhu.semester.ly">JHU</a>
 						<a href="https://umd.semester.ly">UMD</a>
 						<a href="https://uoft.semester.ly">UofT</a>
-						<a href="https://queens.semester.ly">Queen's</a>
+						<!--<a href="https://queens.semester.ly">Queen's</a>-->
 						<a href="https://vandy.semester.ly">Vandy</a>
 						<a href="https://gw.semester.ly">GW</a>
 						<a href="https://chapman.semester.ly">Chapman</a>
@@ -63,7 +63,7 @@
 								<a href="https://jhu.semester.ly">JHU</a>
 								<a href="https://umd.semester.ly">UMD</a>
 								<a href="https://uoft.semester.ly">UofT</a>
-								<a href="https://queens.semester.ly">Queen's</a>
+								<!--<a href="https://queens.semester.ly">Queen's</a>-->
 								<a href="https://vandy.semester.ly">Vandy</a>
 								<a href="https://gw.semester.ly">GW</a>
 								<a href="https://chapman.semester.ly">Chapman</a>


### PR DESCRIPTION
Removed Queens logo and links from the Splash page
Redirect all requests to queens.semester.ly to a 404 styled page that says this website is unavailable by request of the university.