### PR TITLE
add delete account feature flow

### DIFF
--- a/helpers/mixins.py
+++ b/helpers/mixins.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function
 import json
 
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from rest_framework.authentication import SessionAuthentication, BasicAuthentication
 from rest_framework.views import APIView
@@ -49,6 +50,7 @@ class FeatureFlowView(ValidateSubdomainMixin, APIView):
     can be overridden to launch a feature or action on homepage load.
     """
     feature_name = None
+    allow_unauthenticated = True
 
     def get_feature_flow(self, request, *args, **kwargs):
         """
@@ -60,6 +62,8 @@ class FeatureFlowView(ValidateSubdomainMixin, APIView):
         return {}
 
     def get(self, request, *args, **kwargs):
+        if not self.allow_unauthenticated and not request.user.is_authenticated():
+            return HttpResponseRedirect('/')
         self.school = request.subdomain
         self.student = get_student(request)
 

--- a/static/css/timetable/partials/user_settings_modal.scss
+++ b/static/css/timetable/partials/user_settings_modal.scss
@@ -66,6 +66,9 @@
       text-align: center;
       margin-top: 15px;
       text-decoration: underline;
+      &:hover {
+        cursor: pointer;
+      }
     }
 
     .delete-btn {

--- a/static/js/redux/init.jsx
+++ b/static/js/redux/init.jsx
@@ -26,7 +26,7 @@ import {
   lockTimetable,
 } from './actions/timetable_actions';
 import { fetchSchoolInfo } from './actions/school_actions';
-import { fetchCourseClassmates, setCourseInfo } from './actions/modal_actions';
+import { fetchCourseClassmates, setCourseInfo, overrideSettingsShow } from './actions/modal_actions';
 import { receiveCourses } from './actions/search_actions';
 import {
     browserSupportsLocalStorage,
@@ -151,6 +151,9 @@ const handleFlows = featureFlow => (dispatch) => {
       break;
     case 'EXPORT_SIS_TIMETABLE':
       dispatch({ type: ActionTypes.EXPORT_SIS_TIMETABLE });
+      break;
+    case 'DELETE_ACCOUNT':
+      dispatch(overrideSettingsShow(true));
       break;
     default:
       // unexpected feature name

--- a/student/tests.py
+++ b/student/tests.py
@@ -53,6 +53,9 @@ class UrlsTest(UrlTestCase):
         self.assertUrlResolvesToView(
             '/user/reactions/',
             'student.views.ReactionView')
+        self.assertUrlResolvesToView(
+            '/delete_account/',
+            'helpers.mixins.FeatureFlowView')
 
 
 class UserViewTest(APITestCase):

--- a/student/urls.py
+++ b/student/urls.py
@@ -13,6 +13,7 @@
 from django.conf.urls import patterns, url
 from django.contrib import admin
 
+from helpers.mixins import FeatureFlowView
 import student.views
 
 admin.autodiscover()
@@ -22,6 +23,11 @@ urlpatterns = patterns('',
   url(r'^user/logout/$', 'django.contrib.auth.views.logout', {'next_page': '/'}),
   url(r'^unsubscribe/(?P<id>[\w.@+-]+)/(?P<token>[\w.:\-_=]+)/$', student.views.unsubscribe),
   url(r'^user/settings/$', student.views.UserView.as_view()),
+  # TODO: link to issue/PR
+  url(
+    r'^delete_account/$',
+    FeatureFlowView.as_view(
+      feature_name='DELETE_ACCOUNT', allow_unauthenticated=False)),
 
   # timetable management
   url(r'^user/timetables/$', student.views.UserTimetableView.as_view()),

--- a/student/urls.py
+++ b/student/urls.py
@@ -23,7 +23,6 @@ urlpatterns = patterns('',
   url(r'^user/logout/$', 'django.contrib.auth.views.logout', {'next_page': '/'}),
   url(r'^unsubscribe/(?P<id>[\w.@+-]+)/(?P<token>[\w.:\-_=]+)/$', student.views.unsubscribe),
   url(r'^user/settings/$', student.views.UserView.as_view()),
-  # TODO: link to issue/PR
   url(
     r'^delete_account/$',
     FeatureFlowView.as_view(


### PR DESCRIPTION
the delete account feature flow will:
- redirect to / for users that are not logged in
- open the user settings modal for logged in users

an example of how you might include this in the email:
"if you would like to delete your account, you can do so from the user settings modal [link to jhu.semester.ly/delete_account] (note that this link only works if you are logged in)"

feel free to extend this code if you would like to provide different behaviour